### PR TITLE
set fuse search distance from 100 to 1000

### DIFF
--- a/switcher.js
+++ b/switcher.js
@@ -22,7 +22,7 @@
 			tokenize: false,
 			threshold: 0.1,
 			location: 0,
-			distance: 100,
+			distance: 1000,
 			maxPatternLength: 32,
 			keys: ["title", "url"]
 		}),


### PR DESCRIPTION
I tried changing this and it fixed the issue #14 with partial match not working when the tab title is too long, as it searched for title first then url and it can now search and match what I wanted