### PR TITLE
Give the action bar a background color

### DIFF
--- a/switcher.css
+++ b/switcher.css
@@ -305,7 +305,7 @@ li:hover button {
 	}
 
 	#actionBar {
-		background-color: transparent;
+		background-color: #292A2D;
 		box-shadow: -1px 0 1px rgba(0,0,0,0.7);
 	}
 


### PR DESCRIPTION
Right now, the transparent action bar intersects with the tab list when you have >=20 tabs open:
<img width="512" alt="Screen Shot 2020-03-31 at 3 32 40 PM" src="https://user-images.githubusercontent.com/3589480/78038892-4b462200-7365-11ea-9632-29fe606f7321.png">

This fixes that by giving it a background color rather than having is be transparent:
<img width="516" alt="Screen Shot 2020-03-31 at 3 33 03 PM" src="https://user-images.githubusercontent.com/3589480/78038924-57ca7a80-7365-11ea-9403-d070b0c5dba5.png">
